### PR TITLE
replace fa-group with fa-user-friends for MyPlanner 'shared' indictor

### DIFF
--- a/visualize/templates/visualize/scenarios.html
+++ b/visualize/templates/visualize/scenarios.html
@@ -133,7 +133,7 @@
                                                                                        style="text-decoration: none; cursor: default;"
                                                                                        data-toggle="tooltip"
                                                                                        data-placement="right">
-                                                                                        <i class="fa fa-group"></i>
+                                                                                        <i class="fa fa-user-friends"></i>
                                                                                     </a>
 
                                                                                 <span data-bind="click: loadBookmark">
@@ -247,7 +247,7 @@
                                                                             </span>
                                                                             <span rel="tooltip"
                                                                                   data-bind="visible: selectedGroups().length, attr: {title: sharedWith}">
-                                                                                <i class="fa fa-group"></i>
+                                                                                <i class="fa fa-user-friends"></i>
                                                                             </span>
                                                                             <span data-bind='text: name'></span>
                                                                         </td>
@@ -489,7 +489,7 @@
                                                                                        style="text-decoration: none; cursor: default;"
                                                                                        data-toggle="tooltip"
                                                                                        data-placement="right">
-                                                                                        <i class="fa fa-group"></i>
+                                                                                        <i class="fa fa-user-friends"></i>
                                                                                     </a>
 
                                                                                 <span data-bind="text: name"></span>
@@ -609,7 +609,7 @@
                                                                         </span>
                                                                         <span rel="tooltip"
                                                                               data-bind="visible: selectedGroups().length, attr: {title: sharedWith}">
-                                                                            <i class="fa fa-group"></i>
+                                                                            <i class="fa fa-user-friends"></i>
                                                                         </span>
                                                                             <span data-bind='text: name'></span>
                                                                         </td>
@@ -811,7 +811,7 @@
                                                                             </span>
                                                                             <span rel="tooltip"
                                                                                   data-bind="visible: selectedGroups().length, attr: {title: sharedWith}">
-                                                                                <i class="fa fa-group"></i>
+                                                                                <i class="fa fa-user-friends"></i>
                                                                             </span>
                                                                             <span data-bind='text: name'></span>
                                                                         </td>


### PR DESCRIPTION
fa-group icon no longer exists in current versions of FontAwesome. Replacing with fa-user-friends for representing when items in a user's 'MyPlanner' tab are shared.