### PR TITLE
Support for Wagtail 5 and Django 4.2

### DIFF
--- a/visualize/templatetags/in_group.py
+++ b/visualize/templatetags/in_group.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 register = template.Library()
 
@@ -21,5 +21,5 @@ def in_group(user, groups):
         {% endif %}
 
     """
-    group_list = force_text(groups).split(',')
+    group_list = force_str(groups).split(',')
     return bool(user.groups.filter(name__in=group_list).values('name'))


### PR DESCRIPTION
Currently this just replaces 'force_text' with 'force_str' in a called, but otherwise unused template tag 'in_group'.

Django 3.2 supports both functions, so there is no regression in existing deployments with this change.