### PR TITLE
#32 slider widget fails

### DIFF
--- a/visualize/static/js/models.js
+++ b/visualize/static/js/models.js
@@ -1387,7 +1387,7 @@ function layerModel(options, parent) {
         step: 1
       })
       .each(
-        self.drawSlider
+        self.drawSlider.bind(self)
       );
 
       if (dimension.animated) {

--- a/visualize/static/js/models.js
+++ b/visualize/static/js/models.js
@@ -1282,7 +1282,7 @@ function layerModel(options, parent) {
             self.multilayerSliderState[i] = sliderIndex;
             sliderValues.push(self.multilayerValueLookup[dimension][sliderIndex].value.toString());
           } catch(err) {
-            if (self.multilayerSliderState.length > i) {
+            if (self.multilayerSliderState.length > i && self.multilayerValueLookup[dimension][self.multilayerSliderState[i]] != undefined) {
               sliderValues.push(self.multilayerValueLookup[dimension][self.multilayerSliderState[i]].value.toString());
             } else {
               sliderValues.push(self.multilayerValueLookup[dimension][0].value.toString());
@@ -1377,10 +1377,6 @@ function layerModel(options, parent) {
       }
     };
 
-    self.manageDrawSlider = function() {
-      self.drawSlider();
-    };
-
     self.addSlider = function(dimension, value) {
       $( "#" + self.id + "_" + dimension.label + "_multilayerslider" ).slider({
         create: self.multilayerSliderChange,
@@ -1391,13 +1387,11 @@ function layerModel(options, parent) {
         step: 1
       })
       .each(
-          // In Chrome, loading from a URL this needs to be wrapped in an anonymous function. Loading from a SHORTENED URL breaks
-          // providing a named function to wrap the call seems to fix this issue.
-          self.manageDrawSlider
+        self.drawSlider
       );
 
       if (dimension.animated) {
-        if (!$._data( $( "#" + self.id + "_animate_multilayerslider" ).get(0), 'events')) {
+        if ($( "#" + self.id + "_animate_multilayerslider" ).length > 1 && !$._data( $( "#" + self.id + "_animate_multilayerslider" ).get(0), 'events')) {
           $( "#" + self.id + "_animate_multilayerslider" ).change(function(evt) {
             var slider = $( "#" + self.id + "_" + dimension.label + "_multilayerslider" );
             self.multilayerAnimateToggle(this, slider);

--- a/visualize/static/js/models.js
+++ b/visualize/static/js/models.js
@@ -1391,7 +1391,7 @@ function layerModel(options, parent) {
       );
 
       if (dimension.animated) {
-        if ($( "#" + self.id + "_animate_multilayerslider" ).length > 1 && !$._data( $( "#" + self.id + "_animate_multilayerslider" ).get(0), 'events')) {
+        if ($( "#" + self.id + "_animate_multilayerslider" ).length > 0 && !$._data( $( "#" + self.id + "_animate_multilayerslider" ).get(0), 'events')) {
           $( "#" + self.id + "_animate_multilayerslider" ).change(function(evt) {
             var slider = $( "#" + self.id + "_" + dimension.label + "_multilayerslider" );
             self.multilayerAnimateToggle(this, slider);

--- a/visualize/static/js/models.js
+++ b/visualize/static/js/models.js
@@ -1377,6 +1377,10 @@ function layerModel(options, parent) {
       }
     };
 
+    self.manageDrawSlider = function() {
+      self.drawSlider();
+    };
+
     self.addSlider = function(dimension, value) {
       $( "#" + self.id + "_" + dimension.label + "_multilayerslider" ).slider({
         create: self.multilayerSliderChange,
@@ -1387,7 +1391,9 @@ function layerModel(options, parent) {
         step: 1
       })
       .each(
-          self.drawSlider
+          // In Chrome, loading from a URL this needs to be wrapped in an anonymous function. Loading from a SHORTENED URL breaks
+          // providing a named function to wrap the call seems to fix this issue.
+          self.manageDrawSlider
       );
 
       if (dimension.animated) {

--- a/visualize/static/js/models.js
+++ b/visualize/static/js/models.js
@@ -1387,9 +1387,7 @@ function layerModel(options, parent) {
         step: 1
       })
       .each(
-        function() {
-          self.drawSlider();
-        }
+          self.drawSlider
       );
 
       if (dimension.animated) {

--- a/visualize/static/js/state.js
+++ b/visualize/static/js/state.js
@@ -105,23 +105,23 @@ app.establishLayerLoadState = function () {
   *   regardless of what order they come back from the AJAX calls.
   */
 app.activateHashStateLayers = function() {
+  window.setTimeout(function() {
   for (var i = 0; i < app.hashStateLayers.length; i++) {
     var layerStatus = app.hashStateLayers[i].status
     if (layerStatus instanceof layerModel) {
       if (app.viewModel.activeLayers().indexOf(layerStatus) < 0) {
-        window.setTimeout(function() {
           layerStatus.activateLayer("nocompanion", true);
           if (app.hashStateLayers[i].visible == "false" || app.hashStateLayers[i].visible == false) {
             if (layerStatus.visible()){
               layerStatus.toggleVisible();
             }
           }
-        }, 200);
+        }
+      } else {
+        break;
       }
-    } else {
-      break;
     }
-  }
+  }, 200);
 }
 
 app.updateHashStateLayers = function(id, status, visible) {

--- a/visualize/static/js/state.js
+++ b/visualize/static/js/state.js
@@ -109,12 +109,14 @@ app.activateHashStateLayers = function() {
     var layerStatus = app.hashStateLayers[i].status
     if (layerStatus instanceof layerModel) {
       if (app.viewModel.activeLayers().indexOf(layerStatus) < 0) {
-        layerStatus.activateLayer("nocompanion", true);
-        if (app.hashStateLayers[i].visible == "false" || app.hashStateLayers[i].visible == false) {
-          if (layerStatus.visible()){
-            layerStatus.toggleVisible();
+        window.setTimeout(function() {
+          layerStatus.activateLayer("nocompanion", true);
+          if (app.hashStateLayers[i].visible == "false" || app.hashStateLayers[i].visible == false) {
+            if (layerStatus.visible()){
+              layerStatus.toggleVisible();
+            }
           }
-        }
+        }, 200);
       }
     } else {
       break;

--- a/visualize/templates/visualize/includes/layer-row.html
+++ b/visualize/templates/visualize/includes/layer-row.html
@@ -146,7 +146,6 @@
     <tr class="slider-row">
       <!-- ko if: $data.animated -->
         <td class="animated-slider-cell">
-          <span data-bind="text: $parent" style="display: none"></span>
           <div class="slider multilayerslider" data-bind="attr: {id: $parent.id + '_' + label + '_multilayerslider'}"></div>
         </td>
         <td class='animation-check-container'  data-toggle="tooltip" data-placement="left" title="" data-original-title="Animate">

--- a/visualize/templates/visualize/includes/layer-row.html
+++ b/visualize/templates/visualize/includes/layer-row.html
@@ -146,6 +146,7 @@
     <tr class="slider-row">
       <!-- ko if: $data.animated -->
         <td class="animated-slider-cell">
+          <span data-bind="text: $parent" style="display: none"></span>
           <div class="slider multilayerslider" data-bind="attr: {id: $parent.id + '_' + label + '_multilayerslider'}"></div>
         </td>
         <td class='animation-check-container'  data-toggle="tooltip" data-placement="left" title="" data-original-title="Animate">


### PR DESCRIPTION
Fixes #32 -- adds a timeout before loading layers from hash. For Chrome on Windows, this was trying to build slider widgets before the parent elements were created.