### PR TITLE
Fix layerlistindention

### DIFF
--- a/visualize/static/visualize/css/layer-nav.css
+++ b/visualize/static/visualize/css/layer-nav.css
@@ -6,12 +6,16 @@ body.template-visualize .layer-info .layer-text {
 }
 
 body.template-visualize .layer-info .layer-text ul,
-body.template-visualize .layer-info .layer-text ol {
+body.template-visualize .layer-info .layer-text ol,
+.description-box ul,
+.description-box ol {
   padding-left: 2rem;
 }
 
 body.template-visualize .layer-info .layer-text ul li,
-body.template-visualize .layer-info .layer-text ol li {
+body.template-visualize .layer-info .layer-text ol li,
+.description-box ul li,
+.description-box ol li {
   margin: 0.25rem 0;
 }
 

--- a/visualize/static/visualize/css/layer-nav.css
+++ b/visualize/static/visualize/css/layer-nav.css
@@ -5,6 +5,16 @@ body.template-visualize .layer-info .layer-text {
   border-radius: 0.3rem;
 }
 
+body.template-visualize .layer-info .layer-text ul,
+body.template-visualize .layer-info .layer-text ol {
+  padding-left: 2rem;
+}
+
+body.template-visualize .layer-info .layer-text ul li,
+body.template-visualize .layer-info .layer-text ol li {
+  margin: 0.25rem 0;
+}
+
 body.template-visualize .layer-info .layer-text div.sharing-info {
   text-decoration: none;
   cursor: default;


### PR DESCRIPTION
This pull request introduces minor CSS improvements to the styling of lists within the layer information and description boxes. The changes enhance the readability and visual spacing of both unordered and ordered lists.

* Added left padding to `ul` and `ol` elements inside `.layer-text` and `.description-box` to improve indentation.
* Added vertical margin to `li` elements inside `.layer-text` and `.description-box` lists for better spacing between items.