### PR TITLE
Simplify CORS in Dockerized madrona-portal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # -e git+git@bitbucket.org:point97/madrona-features.git@HEAD#egg=madrona_features-master
-rpc4django
+# rpc4django removed — replaced by djangorestframework API views
 django-tinymce>3.3.0

--- a/visualize/api.py
+++ b/visualize/api.py
@@ -41,6 +41,7 @@ class BookmarkListView(APIView):
                 g.mapgroup_set.get().name for g in bookmark.sharing_groups.all()
             ]
             content.append({
+                'id': bookmark.pk,  # Add primary key for DELETE operations
                 'uid': bookmark.uid,
                 'name': bookmark.name,
                 'description': bookmark.description,
@@ -55,6 +56,7 @@ class BookmarkListView(APIView):
                 groups = bookmark.sharing_groups.filter(user__in=[request.user])
                 shared_groups = [g.mapgroup_set.get().name for g in groups]
                 content.append({
+                    'id': bookmark.pk,  # Add primary key for DELETE operations
                     'uid': bookmark.uid,
                     'name': bookmark.name,
                     'description': bookmark.description,
@@ -82,6 +84,7 @@ class BookmarkListView(APIView):
         bookmark.save()
         sharing_groups = [g.name for g in bookmark.sharing_groups.all()]
         return Response([{
+            'id': bookmark.pk,  # Add primary key for consistency
             'uid': bookmark.uid,
             'name': bookmark.name,
             'description': bookmark.description,
@@ -262,6 +265,12 @@ class UserLayerListView(APIView):
             url=data['url'],
             layer_type=data['layer_type'],
             arcgis_layers=data.get('arcgis_layers', ''),
+            wms_slug=data.get('wms_slug'),
+            wms_srs=data.get('wms_srs'),
+            wms_params=data.get('wms_params'),
+            wms_version=data.get('wms_version'),
+            wms_format=data.get('wms_format'),
+            wms_styles=data.get('wms_styles'),
         )
         ul.save()
         sharing_groups = [g.name for g in ul.sharing_groups.all()]

--- a/visualize/api.py
+++ b/visualize/api.py
@@ -141,7 +141,17 @@ class BookmarkShareView(APIView):
 
         bookmark.share_with(None)
         group_names: list[str] = request.data.get('group_names', [])
-        groups = [Group.objects.get(mapgroup__name=gname) for gname in group_names]
+        
+        # Find groups by their mapgroup names, handling cases where groups don't exist
+        groups = []
+        for gname in group_names:
+            try:
+                group = Group.objects.get(mapgroup__name=gname)
+                groups.append(group)
+            except Group.DoesNotExist:
+                # Continue processing other groups even if this one doesn't exist
+                pass
+        
         bookmark.share_with(groups, append=False)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -348,6 +358,16 @@ class UserLayerShareView(APIView):
 
         ul.share_with(None)
         group_names: list[str] = request.data.get('group_names', [])
-        groups = [Group.objects.get(mapgroup__name=gname) for gname in group_names]
+        
+        # Find groups by their mapgroup names, handling cases where groups don't exist
+        groups = []
+        for gname in group_names:
+            try:
+                group = Group.objects.get(mapgroup__name=gname)
+                groups.append(group)
+            except Group.DoesNotExist:
+                # Continue processing other groups even if this one doesn't exist
+                pass
+        
         ul.share_with(groups, append=False)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/visualize/api.py
+++ b/visualize/api.py
@@ -1,0 +1,344 @@
+"""DRF API views replacing the rpc4django /rpc endpoint for the visualize app.
+
+Replaces these former XML-RPC methods:
+    get_bookmarks, add_bookmark, load_bookmark, remove_bookmark, share_bookmark
+    get_user_layers, add_user_layer, load_user_layer, remove_user_layer, share_user_layer
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+# ---------------------------------------------------------------------------
+# Bookmarks
+# ---------------------------------------------------------------------------
+
+class BookmarkListView(APIView):
+    """GET /api/bookmarks/  — list user's own + shared bookmarks.
+    POST /api/bookmarks/ — create a new bookmark.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        from mapgroups.models import MapGroupMember
+        from visualize.models import Bookmark
+
+        content: list[dict[str, Any]] = []
+        bookmark_list = Bookmark.objects.filter(user=request.user)
+
+        for bookmark in bookmark_list:
+            sharing_groups = [
+                g.mapgroup_set.get().name for g in bookmark.sharing_groups.all()
+            ]
+            content.append({
+                'uid': bookmark.uid,
+                'name': bookmark.name,
+                'description': bookmark.description,
+                'hash': bookmark.url_hash,
+                'sharing_groups': sharing_groups,
+                'json': bookmark.json,
+            })
+
+        shared_bookmarks = Bookmark.objects.shared_with_user(request.user)
+        for bookmark in shared_bookmarks:
+            if bookmark not in bookmark_list:
+                groups = bookmark.sharing_groups.filter(user__in=[request.user])
+                shared_groups = [g.mapgroup_set.get().name for g in groups]
+                content.append({
+                    'uid': bookmark.uid,
+                    'name': bookmark.name,
+                    'description': bookmark.description,
+                    'hash': bookmark.url_hash,
+                    'shared': True,
+                    'shared_by_user': bookmark.user.id,
+                    'shared_to_groups': shared_groups,
+                    'shared_by_name': bookmark.user.get_short_name(),
+                    'json': bookmark.json,
+                })
+
+        return Response(content)
+
+    def post(self, request: Request) -> Response:
+        from visualize.models import Bookmark
+
+        data = request.data
+        bookmark = Bookmark(
+            user=request.user,
+            name=data['name'],
+            description=data.get('description', ''),
+            url_hash=data['url_hash'],
+            json=data.get('json', ''),
+        )
+        bookmark.save()
+        sharing_groups = [g.name for g in bookmark.sharing_groups.all()]
+        return Response([{
+            'uid': bookmark.uid,
+            'name': bookmark.name,
+            'description': bookmark.description,
+            'hash': bookmark.url_hash,
+            'sharing_groups': sharing_groups,
+            'json': bookmark.json,
+        }], status=status.HTTP_201_CREATED)
+
+
+class BookmarkDetailView(APIView):
+    """GET /api/bookmarks/<pk>/  — load a bookmark by pk (auth not required).
+    DELETE /api/bookmarks/<pk>/  — remove owner's bookmark.
+    """
+
+    def get_permissions(self) -> list:
+        if self.request.method == 'DELETE':
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get(self, request: Request, pk: int) -> Response:
+        from visualize.models import Bookmark
+
+        bookmark = get_object_or_404(Bookmark, pk=pk)
+        return Response([{
+            'uid': bookmark.uid,
+            'hash': bookmark.url_hash,
+            'json': bookmark.json,
+        }])
+
+    def delete(self, request: Request, pk: int) -> Response:
+        from visualize.models import Bookmark
+
+        bookmark = get_object_or_404(Bookmark, pk=pk, user=request.user)
+        bookmark.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class BookmarkShareView(APIView):
+    """POST /api/bookmarks/<uid>/share/
+
+    Body: {"group_names": ["Group A", "Group B"]}
+    Replaces the previous sharing list wholesale (share_with append=False).
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, uid: str) -> Response:
+        from features.registry import get_feature_by_uid
+
+        bookmark = get_feature_by_uid(uid)
+        viewable, _response = bookmark.is_viewable(request.user)
+        if not viewable:
+            return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+        bookmark.share_with(None)
+        group_names: list[str] = request.data.get('group_names', [])
+        groups = [Group.objects.get(mapgroup__name=gname) for gname in group_names]
+        bookmark.share_with(groups, append=False)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# User Layers
+# ---------------------------------------------------------------------------
+
+class UserLayerListView(APIView):
+    """GET /api/user-layers/  — list user's own + shared layers (auth optional).
+    POST /api/user-layers/ — create a new user layer.
+    """
+
+    def get_permissions(self) -> list:
+        if self.request.method == 'POST':
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get(self, request: Request) -> Response:
+        from visualize.models import UserLayer
+
+        content: list[dict[str, Any]] = []
+
+        try:
+            user_layer_list = UserLayer.objects.filter(user=request.user)
+        except TypeError:
+            user_layer_list = []
+
+        for ul in user_layer_list:
+            sharing_groups = [
+                g.mapgroup_set.get().name
+                for g in ul.sharing_groups.all()
+                if g.mapgroup_set.exists()
+            ]
+            public_groups = [
+                g.name
+                for g in Group.objects.filter(name__in=settings.SHARING_TO_PUBLIC_GROUPS)
+                if g in ul.sharing_groups.all()
+            ]
+            content.append({
+                'id': ul.id,
+                'uid': ul.uid,
+                'name': ul.name,
+                'description': ul.description,
+                'url': ul.url,
+                'layer_type': ul.layer_type,
+                'password_protected': ul.password_protected,
+                'arcgis_layers': ul.arcgis_layers,
+                'sharing_groups': sharing_groups + public_groups,
+                'shared_to_groups': sharing_groups,
+                'owned_by_user': True,
+                'wms_slug': ul.wms_slug,
+                'wms_srs': ul.wms_srs,
+                'wms_params': ul.wms_params,
+                'wms_version': ul.wms_version,
+                'wms_format': ul.wms_format,
+                'wms_styles': ul.wms_styles,
+            })
+
+        try:
+            shared_layers = UserLayer.objects.shared_with_user(request.user)
+        except TypeError:
+            shared_layers = UserLayer.objects.filter(pk=-1)
+
+        for ul in shared_layers:
+            if ul not in user_layer_list:
+                try:
+                    groups = ul.sharing_groups.filter(user__in=[request.user])
+                    permission_groups = [
+                        x.map_group.permission_group
+                        for x in request.user.mapgroupmember_set.all()
+                    ]
+                except TypeError:
+                    groups = []
+                    permission_groups = []
+
+                sharing_groups = [
+                    g.mapgroup_set.get().name
+                    for g in ul.sharing_groups.all()
+                    if g.mapgroup_set.exists() and g in permission_groups
+                ]
+                public_groups = [
+                    g.name
+                    for g in Group.objects.filter(name__in=settings.SHARING_TO_PUBLIC_GROUPS)
+                    if g in ul.sharing_groups.all()
+                ]
+                owned_by_user = len(sharing_groups) > 0
+                content.append({
+                    'id': ul.id,
+                    'uid': ul.uid,
+                    'name': ul.name,
+                    'description': ul.description,
+                    'url': ul.url,
+                    'layer_type': ul.layer_type,
+                    'password_protected': ul.password_protected,
+                    'arcgis_layers': ul.arcgis_layers,
+                    'shared': True,
+                    'shared_by_user': ul.user.id,
+                    'sharing_groups': sharing_groups + public_groups,
+                    'shared_to_groups': sharing_groups,
+                    'shared_by_name': ul.user.get_short_name(),
+                    'owned_by_user': owned_by_user,
+                    'wms_slug': ul.wms_slug,
+                    'wms_srs': ul.wms_srs,
+                    'wms_params': ul.wms_params,
+                    'wms_version': ul.wms_version,
+                    'wms_format': ul.wms_format,
+                    'wms_styles': ul.wms_styles,
+                })
+
+        return Response(content)
+
+    def post(self, request: Request) -> Response:
+        from visualize.models import UserLayer
+
+        data = request.data
+        ul = UserLayer(
+            user=request.user,
+            name=data['name'],
+            description=data.get('description', ''),
+            url=data['url'],
+            layer_type=data['layer_type'],
+            arcgis_layers=data.get('arcgis_layers', ''),
+        )
+        ul.save()
+        sharing_groups = [g.name for g in ul.sharing_groups.all()]
+        return Response([{
+            'uid': ul.uid,
+            'name': ul.name,
+            'description': ul.description,
+            'url': ul.url,
+            'layer_type': ul.layer_type,
+            'arcgis_layers': ul.arcgis_layers,
+            'sharing_groups': sharing_groups,
+            'wms_slug': ul.wms_slug,
+            'wms_srs': ul.wms_srs,
+            'wms_params': ul.wms_params,
+            'wms_version': ul.wms_version,
+            'wms_format': ul.wms_format,
+            'wms_styles': ul.wms_styles,
+        }], status=status.HTTP_201_CREATED)
+
+
+class UserLayerDetailView(APIView):
+    """GET /api/user-layers/<pk>/  — load a user layer (auth not required).
+    DELETE /api/user-layers/<pk>/ — remove owner's user layer.
+    """
+
+    def get_permissions(self) -> list:
+        if self.request.method == 'DELETE':
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get(self, request: Request, pk: int) -> Response:
+        from visualize.models import UserLayer
+
+        ul = get_object_or_404(UserLayer, pk=pk)
+        return Response([{
+            'uid': ul.uid,
+            'name': ul.name,
+            'description': ul.description,
+            'url': ul.url,
+            'layer_type': ul.layer_type,
+            'password_protected': ul.password_protected,
+            'arcgis_layers': ul.arcgis_layers,
+            'wms_slug': ul.wms_slug,
+            'wms_srs': ul.wms_srs,
+            'wms_params': ul.wms_params,
+            'wms_version': ul.wms_version,
+            'wms_format': ul.wms_format,
+            'wms_styles': ul.wms_styles,
+        }])
+
+    def delete(self, request: Request, pk: int) -> Response:
+        from visualize.models import UserLayer
+
+        ul = get_object_or_404(UserLayer, pk=pk, user=request.user)
+        ul.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class UserLayerShareView(APIView):
+    """POST /api/user-layers/<uid>/share/
+
+    Body: {"group_names": ["Group A", "Group B"]}
+    Replaces the previous sharing list wholesale (share_with append=False).
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, uid: str) -> Response:
+        from features.registry import get_feature_by_uid
+
+        ul = get_feature_by_uid(uid)
+        viewable, _response = ul.is_viewable(request.user)
+        if not viewable:
+            return Response({'detail': 'Permission denied.'}, status=status.HTTP_403_FORBIDDEN)
+
+        ul.share_with(None)
+        group_names: list[str] = request.data.get('group_names', [])
+        groups = [Group.objects.get(mapgroup__name=gname) for gname in group_names]
+        ul.share_with(groups, append=False)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/visualize/rpc.py
+++ b/visualize/rpc.py
@@ -1,10 +1,12 @@
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse, HttpResponse
 from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_protect
 from rpc4django import rpcmethod
 from django.conf import settings
 
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def add_bookmark(name, description, url_hash, json, **kwargs):
     from visualize.models import Bookmark
@@ -99,6 +101,7 @@ def load_bookmark(bookmark_id, **kwargs):
     }]
     return content
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def remove_bookmark(key, **kwargs):
     from visualize.models import Bookmark
@@ -108,6 +111,7 @@ def remove_bookmark(key, **kwargs):
     bookmark = get_object_or_404(Bookmark, id=key, user=request.user)
     bookmark.delete()
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def share_bookmark(bookmark_uid, group_names, **kwargs):
     from django.contrib.auth.models import Group
@@ -137,6 +141,7 @@ def share_bookmark(bookmark_uid, group_names, **kwargs):
 ######################################################
 
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def add_user_layer(name, description, url, layer_type, arcgis_layers, **kwargs):
     from visualize.models import UserLayer
@@ -163,6 +168,7 @@ def add_user_layer(name, description, url, layer_type, arcgis_layers, **kwargs):
     return content
 
 @rpcmethod(login_required=False)
+@csrf_protect
 def get_user_layers(**kwargs):
     """Return a list of user layer objects for the current user.
     """
@@ -294,6 +300,7 @@ def load_user_layer(user_layer_id, **kwargs):
     }]
     return content
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def remove_user_layer(key, **kwargs):
     from visualize.models import UserLayer
@@ -303,6 +310,7 @@ def remove_user_layer(key, **kwargs):
     userLayer = get_object_or_404(UserLayer, id=key, user=request.user)
     userLayer.delete()
 
+@csrf_protect
 @rpcmethod(login_required=True)
 def share_user_layer(user_layer_uid, group_names, **kwargs):
     from django.contrib.auth.models import Group

--- a/visualize/static/js/bookmarks.js
+++ b/visualize/static/js/bookmarks.js
@@ -4,6 +4,7 @@ function bookmarkModel(options) {
 
     scenarioModel.apply(this, arguments);
 
+    self.id = options.id;  // Primary key for DELETE operations
     self.uid = options.uid;
     self.name = options.name;
     self.description = options.description;
@@ -76,7 +77,7 @@ function bookmarkModel(options) {
     // get the url from a bookmark
     self.getBookmarkUrl = function() {
         var host = window.location.href.split('#')[0];
-        return host + "#bookmark=" + self.id.replace(/\D/g,''); //We just want the integer ID, this strips away all non-numeric text
+        return host + "#bookmark=" + self.id; // Now self.id is the numeric primary key
     };
 
     self.getBookmarkState = function() {
@@ -92,6 +93,23 @@ function bookmarkModel(options) {
 
 function bookmarksModel(options) {
     var self = this;
+
+    // Get CSRF token for DRF endpoints - defined once for reuse
+    function getCsrfToken() {
+        var name = 'csrftoken=';
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for(var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return null;
+    }
 
     // list of bookmarks
     self.bookmarksList = ko.observableArray();
@@ -147,14 +165,21 @@ function bookmarksModel(options) {
     };
 
     self.loadBookmarkFromHash = function(bookmark_id) {
-      $.jsonrpc('load_bookmark', [bookmark_id], {
-          success: function(result) {
-            app.loadState(JSON.parse(result[0].json));
-          },
-          error: function(result) {
-
-          }
-      });
+        var csrfToken = getCsrfToken();
+        var ajaxOptions = {
+            url: '/api/bookmarks/' + bookmark_id + '/',
+            method: 'GET',
+            success: function(result) {
+                app.loadState(JSON.parse(result[0].json));
+            },
+            error: function(result) {
+                console.error('Failed to load bookmark:', result);
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     };
 
     self.getCurrentBookmarkURL = function() {
@@ -303,8 +328,22 @@ function bookmarksModel(options) {
             "Remove Bookmark?", 
             `Are you sure you wish to delete your bookmark "${bookmark.name}"?`,
             function(){
-                $.jsonrpc('remove_bookmark', [bookmark.uid],
-                        {complete: self.getBookmarks});
+                var csrfToken = getCsrfToken();
+                var ajaxOptions = {
+                    url: '/api/bookmarks/' + bookmark.id + '/',  // Using bookmark.id (pk) not uid
+                    method: 'DELETE',
+                    success: function() {
+                        self.getBookmarks();
+                    },
+                    error: function(result) {
+                        console.error('Failed to remove bookmark:', result);
+                        self.getBookmarks(); // Refresh list anyway
+                    }
+                };
+                if (csrfToken) {
+                    ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+                }
+                $.ajax(ajaxOptions);
             }
         );
     };
@@ -373,15 +412,28 @@ function bookmarksModel(options) {
         order++;
 
       }
-      $.jsonrpc('add_bookmark',
-               [
-                 name,
-                 description,
-                 window.location.hash.slice(1),
-                 JSON.stringify(state_json),
-               ],
-               {complete: self.getBookmarks}
-      );
+        var csrfToken = getCsrfToken();
+        var ajaxOptions = {
+            url: '/api/bookmarks/',
+            method: 'POST',
+            data: {
+                'name': name,
+                'description': description,
+                'url_hash': window.location.hash.slice(1),
+                'json': JSON.stringify(state_json)
+            },
+            success: function(result) {
+                self.getBookmarks();
+            },
+            error: function(result) {
+                console.error('Failed to add bookmark:', result);
+                self.getBookmarks(); // Refresh list anyway
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     }
 
     // get bookmark sharing groups for this user
@@ -420,13 +472,16 @@ function bookmarksModel(options) {
         }
 
         // load bookmarks from server while syncing with client
-        //if the user is logged in, ajax call to sync bookmarks with server
-        $.jsonrpc('get_bookmarks', [], {
+        var csrfToken = getCsrfToken();
+        var ajaxOptions = {
+            url: '/api/bookmarks/',
+            method: 'GET',
             success: function(result) {
                 var bookmarks = result || [];
                 var blist = [];
                 for (var i=0; i < bookmarks.length; i++) {
                     var bookmark = new bookmarkModel( {
+                        id: bookmarks[i].id,  // Add primary key for DELETE operations
                         state: $.deparam(bookmarks[i].hash),
                         name: bookmarks[i].name,
                         description: bookmarks[i].description,
@@ -456,9 +511,13 @@ function bookmarksModel(options) {
                 self.bookmarksList(blist);
             },
             error: function(result) {
-
+                console.error('Failed to get bookmarks:', result);
             }
-        });
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
 
         self.getSharingGroups();
     };
@@ -469,10 +528,25 @@ function bookmarksModel(options) {
         var data = { 'bookmark': self.sharingBookmark().uid,
         'groups': self.sharingBookmark().selectedGroups() };
 
-        $.jsonrpc('share_bookmark',
-                  [self.sharingBookmark().uid,
-                   self.sharingBookmark().selectedGroups()],
-                  {complete: self.getBookmarks});
+        var csrfToken = getCsrfToken();
+        var ajaxOptions = {
+            url: '/api/bookmarks/' + self.sharingBookmark().uid + '/share/',
+            method: 'POST',
+            data: {
+                'group_names': self.sharingBookmark().selectedGroups()
+            },
+            success: function() {
+                self.getBookmarks();
+            },
+            error: function(result) {
+                console.error('Failed to share bookmark:', result);
+                self.getBookmarks(); // Refresh list anyway
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     };
 
     self.restoreState = function() {

--- a/visualize/static/js/bookmarks.js
+++ b/visualize/static/js/bookmarks.js
@@ -532,9 +532,10 @@ function bookmarksModel(options) {
         var ajaxOptions = {
             url: '/api/bookmarks/' + self.sharingBookmark().uid + '/share/',
             method: 'POST',
-            data: {
-                'group_names': self.sharingBookmark().selectedGroups()
-            },
+            contentType: 'application/json',
+            data: JSON.stringify({
+                group_names: self.sharingBookmark().selectedGroups()
+            }),
             success: function() {
                 self.getBookmarks();
             },

--- a/visualize/static/js/drawing.js
+++ b/visualize/static/js/drawing.js
@@ -118,9 +118,39 @@ function drawingModel(options) {
         app.viewModel.scenarios.drawingList.remove(drawing);
 
         //remove from server-side db (this should provide error message to the user on fail)
-        $.jsonrpc('delete_drawing', [drawing.uid], {
-            //complete: drawingModel.loadDrawingList
-        });
+        // Get CSRF token for DRF endpoint
+        function getCsrfToken() {
+            var name = 'csrftoken=';
+            var decodedCookie = decodeURIComponent(document.cookie);
+            var ca = decodedCookie.split(';');
+            for(var i = 0; i < ca.length; i++) {
+                var c = ca[i];
+                while (c.charAt(0) == ' ') {
+                    c = c.substring(1);
+                }
+                if (c.indexOf(name) == 0) {
+                    return c.substring(name.length, c.length);
+                }
+            }
+            return null;
+        }
+
+        var csrfToken = getCsrfToken();
+        var ajaxOptions = {
+            url: '/api/drawings/' + drawing.uid + '/',
+            method: 'DELETE',
+            success: function() {
+                // Drawing successfully deleted from server
+            },
+            error: function(result) {
+                console.error('Failed to delete drawing:', result);
+                // Could add drawing back to lists on error if needed
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     };
 
     self.shapefileDownloadLink = function() {

--- a/visualize/static/js/scenarios.js
+++ b/visualize/static/js/scenarios.js
@@ -2390,12 +2390,18 @@ $('#designsTab').on('show.bs.tab', function (e) {
             }
         });
 
-        $.jsonrpc('get_sharing_groups', [], {
+        $.ajax({
+            url: '/api/sharing-groups/',
+            method: 'GET',
+            dataType: 'json',
             success: function(result) {
                 app.viewModel.scenarios.sharingGroups(result);
                 if (result.length) {
                     app.viewModel.scenarios.hasSharingGroups(true);
                 }
+            },
+            error: function(result) {
+                console.error('Failed to load sharing groups:', result);
             }
         });
     }

--- a/visualize/static/js/userlayers.js
+++ b/visualize/static/js/userlayers.js
@@ -3,6 +3,7 @@ function userLayerModel(options) {
 
     scenarioModel.apply(this, arguments);
 
+    self.id = options.id;
     self.uid = options.uid;
     self.name = options.name;
     self.description = options.description;
@@ -182,6 +183,23 @@ function userLayerModel(options) {
 
 function userLayersModel(options) {
     var self = this;
+
+    // Helper function to get CSRF token (same as jsonrpc.js)
+    function getCsrfToken() {
+        var name = 'csrftoken=';
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for(var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return null;
+    }
 
     self.userLayersList = ko.observableArray();
 
@@ -380,29 +398,59 @@ function userLayersModel(options) {
             "Remove Layer?", 
             `Are you sure you wish to delete your imported layer "${userLayer.name}"?`,
             function(){
-                $.jsonrpc('remove_user_layer', [userLayer.uid],
-                  {complete: self.getUserLayers});
+                var csrfToken = getCsrfToken();
+                console.log('DELETE CSRF Token:', csrfToken ? csrfToken.substring(0, 10) + '...' : 'null');
+                var ajaxOptions = {
+                    url: '/api/user-layers/' + userLayer.id + '/',
+                    method: 'DELETE',
+                    success: function() {
+                        self.getUserLayers();
+                    },
+                    error: function(result) {
+                        console.error('Failed to remove user layer:', result);
+                        self.getUserLayers();
+                    }
+                };
+                if (csrfToken) {
+                    ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+                }
+                $.ajax(ajaxOptions);
             }
         );
     };
 
     self.addUserLayer = function(name, description, layer_type, url, arcgis_layers, wms_slug, wms_srs, wms_params, wms_version, wms_format, wms_styles) {
-        $.jsonrpc('add_user_layer', 
-            [
-                name,
-                description,
-                layer_type,
-                url,
-                arcgis_layers,
-                wms_slug,
-                wms_srs,
-                wms_params,
-                wms_version,
-                wms_format,
-                wms_styles,
-            ],
-            {complete: self.getUserLayers}
-        );
+        var csrfToken = getCsrfToken();
+        console.log('ADD CSRF Token:', csrfToken ? csrfToken.substring(0, 10) + '...' : 'null');
+        var ajaxOptions = {
+            url: '/api/user-layers/',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                name: name,
+                description: description,
+                layer_type: layer_type,
+                url: url,
+                arcgis_layers: arcgis_layers,
+                wms_slug: wms_slug,
+                wms_srs: wms_srs,
+                wms_params: wms_params,
+                wms_version: wms_version,
+                wms_format: wms_format,
+                wms_styles: wms_styles
+            }),
+            success: function() {
+                self.getUserLayers();
+            },
+            error: function(result) {
+                console.error('Failed to add user layer:', result);
+                self.getUserLayers();
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     }
 
     // get user layer sharing groups for this user
@@ -446,13 +494,17 @@ function userLayersModel(options) {
             }
         }
 
-        $.jsonrpc('get_user_layers', [], {
+        $.ajax({
+            url: '/api/user-layers/',
+            method: 'GET',
+            dataType: 'json',
             success: function(result) {
                 self.userLayersList.removeAll();
                 var user_layers = result || [];
                 var ullist = [];
                 for (var i=0; i < user_layers.length; i++) {
                     var user_layer = new userLayerModel( {
+                        id: user_layers[i].id,
                         name: user_layers[i].name,
                         description: user_layers[i].description,
                         url: user_layers[i].url,
@@ -481,7 +533,7 @@ function userLayersModel(options) {
                 self.showUnloadedUserLayers();
             },
             error: function(result) {
-
+                console.error('Failed to load user layers:', result);
             }
         });
 
@@ -552,10 +604,27 @@ function userLayersModel(options) {
             'user_layer': self.sharingUserLayer().uid,
             'groups': self.sharingUserLayer().selectedGroups() };
 
-        $.jsonrpc('share_user_layer',
-                  [self.sharingUserLayer().uid,
-                   self.sharingUserLayer().selectedGroups()],
-                  {complete: self.getUserLayers});
+        var csrfToken = getCsrfToken();
+        console.log('SHARE CSRF Token:', csrfToken ? csrfToken.substring(0, 10) + '...' : 'null');
+        var ajaxOptions = {
+            url: '/api/user-layers/' + self.sharingUserLayer().uid + '/share/',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                group_names: self.sharingUserLayer().selectedGroups()
+            }),
+            success: function() {
+                self.getUserLayers();
+            },
+            error: function(result) {
+                console.error('Failed to share user layer:', result);
+                self.getUserLayers();
+            }
+        };
+        if (csrfToken) {
+            ajaxOptions.headers = { 'X-CSRFToken': csrfToken };
+        }
+        $.ajax(ajaxOptions);
     };
 
     self.populateLayerIndexCallback = function() {

--- a/visualize/urls.py
+++ b/visualize/urls.py
@@ -7,6 +7,11 @@ from django.views.generic.base import TemplateView
 from rest_framework import routers, serializers, viewsets, permissions
 from .models import Bookmark
 
+from .api import (
+    BookmarkListView, BookmarkDetailView, BookmarkShareView,
+    UserLayerListView, UserLayerDetailView, UserLayerShareView,
+)
+
 class BookmarkSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Bookmark
@@ -31,4 +36,14 @@ urlpatterns = [
     re_path('^rest/', include(router.urls)),
     re_path('^get_user_layers', get_user_layers),
     re_path(r'^$', show_planner, name="planner"),
+]
+
+# DRF API patterns — mounted at /api/ by the project urls.py
+api_urlpatterns = [
+    re_path(r'^bookmarks/$', BookmarkListView.as_view()),
+    re_path(r'^bookmarks/(?P<pk>\d+)/$', BookmarkDetailView.as_view()),
+    re_path(r'^bookmarks/(?P<uid>\w+)/share/$', BookmarkShareView.as_view()),
+    re_path(r'^user-layers/$', UserLayerListView.as_view()),
+    re_path(r'^user-layers/(?P<pk>\d+)/$', UserLayerDetailView.as_view()),
+    re_path(r'^user-layers/(?P<uid>\w+)/share/$', UserLayerShareView.as_view()),
 ]


### PR DESCRIPTION
DRF API views replacing the rpc4django /rpc endpoint for the visualize app.

Replaces these former XML-RPC methods:
    get_bookmarks, add_bookmark, load_bookmark, remove_bookmark, share_bookmark
    get_user_layers, add_user_layer, load_user_layer, remove_user_layer, share_user_layer

Adds API endpoints