### PR TITLE
Remove polyfill scripts for obsolete browser support in planner.html

### DIFF
--- a/visualize/templates/visualize/planner.html
+++ b/visualize/templates/visualize/planner.html
@@ -36,18 +36,12 @@
         <link href="{% static 'visualize/css/my-planner.css' %}" rel="stylesheet">
         {% if MAP_LIBRARY == 'ol5' %}
           <link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css" type="text/css">
-          <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
-          <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
         {% endif %}
         {% if MAP_LIBRARY == 'ol6' %}
           <link rel="stylesheet" type="text/css" href="{% static 'assets/openlayers/ol.css' %}">
-          <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
-          <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
         {% endif %}
         {% if MAP_LIBRARY == 'ol8' %}
           <link rel="stylesheet" type="text/css" href="{% static 'assets/openlayers/ol8/ol.css' %}">
-          <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
-          <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
         {% endif %}
         {% if not MAP_LIBRARY == 'ol2' %}
           <link href="{% static 'visualize/css/' %}{{ MAP_LIBRARY }}.css" rel="stylesheet">


### PR DESCRIPTION
`cdn.polyfill.io` domain has been blocked by browsers for security reasons since 2024